### PR TITLE
Update Links to `myst` Format

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -88,6 +88,9 @@ sphinx:
       launch_buttons:
         colab_url                 : https://colab.research.google.com
     intersphinx_mapping:
+      pyprog:
+        - https://python-programming.quantecon.org/
+        - null
       intro: 
         - https://intro.quantecon.org/
         - null

--- a/lectures/additive_functionals.md
+++ b/lectures/additive_functionals.md
@@ -1264,10 +1264,10 @@ These probability density functions help us understand mechanics underlying the 
 
 ### Multiplicative Martingale as Likelihood Ratio Process
 
-[This lecture](https://python.quantecon.org/likelihood_ratio_process.html) studies **likelihood processes**
+{doc}`This lecture <stats:likelihood_ratio_process>` studies **likelihood processes**
 and **likelihood ratio processes**.
 
 A **likelihood ratio process** is  a  multiplicative  martingale with mean unity.
 
 Likelihood ratio processes exhibit the peculiar property that naturally also appears
-[here](https://python.quantecon.org/likelihood_ratio_process.html).
+{doc}`here <stats:likelihood_ratio_process>`.

--- a/lectures/discrete_dp.md
+++ b/lectures/discrete_dp.md
@@ -92,7 +92,7 @@ Among other things, it offers
 * the ability to scale to large problems by minimizing vectorized operators and allowing operations on sparse matrices
 
 JIT compilation relies on [Numba](http://numba.pydata.org/), which should work
-seamlessly if you are using [Anaconda](https://www.anaconda.com/download/) as [suggested](https://python-programming.quantecon.org/getting_started.html).
+seamlessly if you are using [Anaconda](https://www.anaconda.com/download/) as {doc}`suggested <pyprog:getting_started>`.
 
 ### References
 

--- a/lectures/entropy.md
+++ b/lectures/entropy.md
@@ -30,8 +30,8 @@ Among the senses of entropy, we'll encounter these
 * A frequency domain criterion for constructing robust decision rules 
 
 The concept of entropy plays an important role in robust control formulations described in this lecture 
-[Risk and Model Uncertainty](https://python-advanced.quantecon.org/five_preferences.html) and in this lecture
-[Robustness](https://python-advanced.quantecon.org/robustness.html).
+{doc}`Risk and Model Uncertainty <tools:five_preferences>` and in this lecture
+{doc}`Robustness <tools:robustness>`.
 
 
 

--- a/lectures/linear_algebra.md
+++ b/lectures/linear_algebra.md
@@ -65,7 +65,7 @@ These are the kinds of topics addressed by linear algebra.
 
 In this lecture we will cover the basics of linear and matrix algebra, treating both theory and computation.
 
-We admit some overlap with [this lecture](https://python-programming.quantecon.org/numpy.html), where operations on NumPy arrays were first explained.
+We admit some overlap with {doc}`this lecture <pyprog:numpy>`, where operations on NumPy arrays were first explained.
 
 Note that this lecture is more theoretical than most, and contains background
 material that will be used in applications as we go along.

--- a/lectures/troubleshooting.md
+++ b/lectures/troubleshooting.md
@@ -33,7 +33,7 @@ The basic assumption of the lectures is that code in a lecture should execute wh
 1. it is executed in a Jupyter notebook and
 1. the notebook is running on a machine with the latest version of Anaconda Python.
 
-You have installed Anaconda, haven't you, following the instructions in [this lecture](https://python-programming.quantecon.org/getting_started.html)?
+You have installed Anaconda, haven't you, following the instructions in {doc}`this lecture <pyprog:getting_started>`?
 
 Assuming that you have, the most common source of problems for our readers is that their Anaconda distribution is not up to date.
 


### PR DESCRIPTION
This completes the first stage of https://github.com/QuantEcon/meta/issues/119