### PR TITLE
MAINT: remove %matplotlib inline and contents directive

### DIFF
--- a/lectures/additive_functionals.md
+++ b/lectures/additive_functionals.md
@@ -25,10 +25,6 @@ kernelspec:
 ```{index} single: Models; Additive functionals
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython3
@@ -78,7 +74,6 @@ import numpy as np
 import scipy.linalg as la
 import quantecon as qe
 import matplotlib.pyplot as plt
-%matplotlib inline
 from scipy.stats import norm, lognorm
 ```
 

--- a/lectures/arma.md
+++ b/lectures/arma.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # {index}`Covariance Stationary Processes <single: Covariance Stationary Processes>`
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython
@@ -95,7 +91,6 @@ Let's start with some imports:
 ```{code-cell} ipython
 import numpy as np
 import matplotlib.pyplot as plt
-%matplotlib inline
 import quantecon as qe
 ```
 

--- a/lectures/classical_filtering.md
+++ b/lectures/classical_filtering.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Classical Prediction and Filtering With Linear Algebra
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 This is a sequel to the earlier lecture {doc}`Classical Control with Linear Algebra <lu_tricks>`.

--- a/lectures/discrete_dp.md
+++ b/lectures/discrete_dp.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # {index}`Discrete State Dynamic Programming <single: Discrete State Dynamic Programming>`
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython
@@ -66,7 +62,6 @@ Let's start with some imports:
 ```{code-cell} ipython
 import numpy as np
 import matplotlib.pyplot as plt
-%matplotlib inline
 import quantecon as qe
 import scipy.sparse as sparse
 from quantecon import compute_fixed_point

--- a/lectures/estspec.md
+++ b/lectures/estspec.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Spectra; Estimation
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython
@@ -59,7 +55,6 @@ Let's start with some standard imports:
 ```{code-cell} ipython
 import numpy as np
 import matplotlib.pyplot as plt
-%matplotlib inline
 from quantecon import ARMA, periodogram, ar_periodogram
 ```
 

--- a/lectures/finite_markov.md
+++ b/lectures/finite_markov.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # {index}`Finite Markov Chains <single: Finite Markov Chains>`
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython

--- a/lectures/five_preferences.md
+++ b/lectures/five_preferences.md
@@ -73,7 +73,6 @@ from numba import njit
 :tags: [hide-input]
 
 # Plotting parameters
-%matplotlib inline
 %config InlineBackend.figure_format='retina'
 
 plt.rc('text', usetex=True)

--- a/lectures/linear_algebra.md
+++ b/lectures/linear_algebra.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Linear Algebra
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 Linear algebra is one of the most useful branches of applied mathematics for economists to invest in.

--- a/lectures/lu_tricks.md
+++ b/lectures/lu_tricks.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Classical Control with Linear Algebra
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 In an earlier lecture [Linear Quadratic Dynamic Programming Problems](https://python-intro.quantecon.org/lqcontrol.html), we have studied how to solve a special
@@ -59,7 +55,6 @@ Let's start with some standard imports:
 ```{code-cell} ipython
 import numpy as np
 import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 ### References

--- a/lectures/newton_method.md
+++ b/lectures/newton_method.md
@@ -24,10 +24,6 @@ kernelspec:
 
 # Using Newton's Method to Solve Economic Models
 
-```{contents} Contents
-:depth: 2
-```
-
 ```{seealso}
 **GPU:** A version of this lecture which makes use of [jax](https://jax.readthedocs.io) to run the code
 on a `GPU` is [available here](https://jax.quantecon.org/newtons_method.html)

--- a/lectures/rob_markov_perf.md
+++ b/lectures/rob_markov_perf.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Robust Markov Perfect Equilibrium
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython
@@ -58,7 +54,6 @@ import numpy as np
 import quantecon as qe
 from scipy.linalg import solve
 import matplotlib.pyplot as plt
-%matplotlib inline
 ```
 
 ### Basic Setup

--- a/lectures/robustness.md
+++ b/lectures/robustness.md
@@ -25,10 +25,6 @@ kernelspec:
 ```{index} single: Robustness
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython3
@@ -85,7 +81,6 @@ import pandas as pd
 import numpy as np
 from scipy.linalg import eig
 import matplotlib.pyplot as plt
-%matplotlib inline
 import quantecon as qe
 ```
 

--- a/lectures/stationary_densities.md
+++ b/lectures/stationary_densities.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Markov Chains; Continuous State
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython
@@ -78,7 +74,6 @@ Let's begin with some imports:
 ```{code-cell} ipython
 import numpy as np
 import matplotlib.pyplot as plt
-%matplotlib inline
 from scipy.stats import lognorm, beta
 from quantecon import LAE
 from scipy.stats import norm, gaussian_kde

--- a/lectures/troubleshooting.md
+++ b/lectures/troubleshooting.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Troubleshooting
 
-```{contents} Contents
-:depth: 2
-```
-
 This page is for readers experiencing errors when running the code from the lectures.
 
 ## Fixing Your Local Environment

--- a/lectures/von_neumann_model.md
+++ b/lectures/von_neumann_model.md
@@ -23,10 +23,6 @@ kernelspec:
 
 # Von Neumann Growth Model (and a Generalization)
 
-```{contents} Contents
-:depth: 2
-```
-
 This lecture uses the class `Neumann` to calculate key objects of a
 linear growth model of John von Neumann {cite}`von1937uber` that was generalized by
 Kemeny, Morgenstern and Thompson {cite}`kemeny1956generalization`.


### PR DESCRIPTION
This PR addresses https://github.com/QuantEcon/meta/issues/134 and removes `contents` directives to simplify